### PR TITLE
add vim plugin to use odpdown easily out of the editor

### DIFF
--- a/plugins/vim/odpdown.txt
+++ b/plugins/vim/odpdown.txt
@@ -1,0 +1,31 @@
+*odpdown.txt* *ShowSlides* Plugin to write presentations as markdown
+
+The following commands are available from the odpdown plugin:
+
+:ShowSlides show                generates a presentation from the markdown in
+                                the current buffer and opens the result with
+                                LibreOffice. If run repeatedly, the previous
+                                result is replaced in LibreOffice (so the
+                                previous result is closed), unless it was
+                                modified.
+
+:ShowSlides                     short for :ShowSlides show
+
+:ShowSlides                     as :ShowSlides show, but start in fullscreen
+                                presentation mode
+
+:ShowSlides example             fills a buffer with example markdown
+
+:ShowSlides settings            shows the current setting for the odp generator
+
+:ShowSlides autofit [on|off]    toggles odpdowns autofit setting
+:ShowSlides breakmaster NAME    sets the breakmaster to use
+:ShowSlides contentmaster NAME  sets the contentmaster to use
+:ShowSlides highlight STYLE     sets the code highlight style to use
+
+All of the above commands are also available as :Odpdown, which is an alias for
+:ShowSlides.
+
+More details on odpdown setting can be found at:
+
+ https://github.com/thorstenb/odpdown

--- a/plugins/vim/odpdown.vim
+++ b/plugins/vim/odpdown.vim
@@ -1,0 +1,194 @@
+" Vim global plugin for creating LibreOffice slides from markdown
+
+if exists("g:loaded_odpdown")
+  finish
+endif
+let g:loaded_odpdown = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+let s:odpdown='/home/bjoern/.local/bin/odpdown'
+let s:breakmaster='Discreet_25_20Dark1'
+let s:contentmaster='Discreet_25_20Dark'
+let s:template=$HOME . '/.vim/plugin/odpdown_data/discreet-dark.odp'
+let s:highlightstyle='colorful'
+let s:autofit='on'
+let s:lastodp=''
+let s:currentodp=''
+let s:lastodp=''
+
+function s:Update()
+  let l:markdownfile=tempname()
+  let s:lastodp=s:currentodp
+  let s:currentodp=l:markdownfile . '.odp'
+  let l:oldmakeprg=&mp
+  let l:makeargs=''
+  if s:autofit != 'on'
+    let l:makeargs.= ' --no-autofit'
+  endif
+  let l:makeargs.= ' --highlight-style ' . s:highlightstyle
+  if exists('s:breakmaster')
+    let l:makeargs.=' --break-master ' . s:breakmaster
+  endif
+  if exists('s:contentmaster')
+    let l:makeargs.=' --content-master ' . s:contentmaster
+  endif
+  let l:makeargs.=' ' . l:markdownfile . ' ' . s:template . ' ' . s:currentodp
+  let &mp=s:odpdown
+  execute 'write! ' . l:markdownfile
+  execute 'make ' . l:makeargs
+  execute 'silent !rm ' . l:markdownfile
+  set mp=l:oldmakeprg
+endfunction
+
+function s:Autofit(args)
+  if len(a:args) == 0
+    echo 'Autofit is currently: ' . s:autofit . '.'
+  else
+    if a:args[0] ==? 'on' || a:args[0] ==? 'yes' || a:args[0] ==? 'active'
+      let s:autofit = 'on'
+    else
+      let s:autofit = 'off'
+    endif
+    echo 'Autofit is now: ' . s:autofit . '.'
+  endif
+endfunction
+
+function s:BreakMaster(args)
+  if len(a:args) == 0
+    echo 'The break-master has been disabled.'
+    unlet s:breakmaster
+  else
+    let s:breakmaster=a:args[0]
+    echo 'Break-master set to "' . s:breakmaster . '" now.'
+  endif
+endfunction
+
+function s:ContentMaster(args)
+  if len(a:args) == 0
+    echo 'The content-master has been disabled.'
+    unlet s:contentmaster
+  else
+    let s:contentmaster=a:args[0]
+    echo 'Content-master set to "' . s:contentmaster . '" now.'
+  endif
+endfunction
+
+function s:Example()
+  if &mod
+    new
+  endif
+  read $HOME/.vim/plugin/odpdown_data/demo-full.md
+  set filetype=markdown
+endfunction
+
+function s:Highlightstyle(args)
+  if len(a:args) == 0
+    echo 'The current highlight style is: "' . s:highlightstyle . '".'
+  else
+    let s:highlightstyle=a:args[0]
+    echo 'Highlight style set to "' . s:highlightstyle . '" now.'
+  endif
+endfunction
+
+function s:Present()
+  call s:Update()
+  let l:cmd='python3 '. $HOME . '/.vim/plugin/odpdown_data/odpdownhelper.py --present --file ' . s:currentodp
+  if len(s:lastodp)
+    let l:cmd.=' --oldfile ' . s:lastodp
+  endif
+  execute 'silent ! ' . l:cmd
+endfunction
+
+function s:Settings()
+  echo 'Autofit is: ' . s:autofit . '.'
+  if !exists('s:breakmaster')
+    echo 'The break-master has been disabled.'
+  else
+    echo 'The current break-master is: "' . s:breakmaster . '".'
+  endif
+  if !exists('s:contentmaster')
+    echo 'The content-master has been disabled.'
+  else
+    echo 'The current content-master is: "' . s:contentmaster . '".'
+  endif
+  echo 'The current highlight style is: "' . s:highlightstyle . '".'
+  echo 'The current template is: "' . s:template . '".'
+endfunction
+
+function s:Show()
+  call s:Update()
+  let l:cmd='python3 '. $HOME . '/.vim/plugin/odpdown_data/odpdownhelper.py --file ' . s:currentodp
+  if len(s:lastodp)
+    let l:cmd.=' --oldfile ' . s:lastodp
+  endif
+  execute 'silent ! ' . l:cmd
+endfunction
+
+function s:Template(args)
+  if len(a:args) == 0
+    echo 'The current template is: "' . s:template . '".'
+  else
+    let s:template=a:args[0]
+    echo 'Template set to "' . s:template . '" now.'
+  endif
+endfunction
+
+function s:ShowSlides(...)
+  if a:0 == 0
+    call s:Show()
+  else
+    if a:000[0] == 'autofit'
+      call s:Autofit(a:000[1:])
+    elseif a:000[0] == 'breakmaster'
+      call s:BreakMaster(a:000[1:])
+    elseif a:000[0] == 'contentmaster'
+      call s:ContentMaster(a:000[1:])
+    elseif a:000[0] == 'example'
+      call s:Example()
+    elseif a:000[0] == 'highlight'
+      call s:Highlightstyle(a:000[1:])
+    elseif a:000[0] == 'settings'
+      call s:Settings()
+    elseif a:000[0] == 'show'
+      call s:Show()
+    elseif a:000[0] == 'present'
+      call s:Present()
+    elseif a:000[0] == 'template'
+      echo 'calling Template with ' . join(a:000[1:])
+      call s:Template(a:000[1:])
+    else
+      echo 'Unkown :ShowSlides subcommand, sorry.'
+    endif
+  endif
+endfunction
+
+function s:Complete(ArgLead, CmdLine, Pos)
+let l:completions=['autofit', 'breakmaster', 'contentmaster', 'example', 'highlight', 'settings', 'show', 'present', 'template']
+if match(a:CmdLine, 'autofit') > 0
+  let l:completions=['on', 'off']
+endif
+if match(a:CmdLine, 'highlight') > 0
+  let l:completions=['default', 'emacs', 'friendly', 'colorful' ]
+endif
+if match(a:CmdLine, 'template') > 0
+  let l:completions=glob(a:ArgLead . '*', 1, 1)
+endif
+if match(a:CmdLine, 'example') > 0 || match(a:CmdLine, 'settings') > 0 || match(a:CmdLine, 'show') > 0 || match(a:CmdLine, 'present') > 0 || match(a:CmdLine, 'breakmaster') > 0 || match(a:CmdLine, 'contentmaster') > 0
+  let l:completions=[]
+endif
+return l:completions
+endfunction
+
+if !exists(":ShowSlides")
+  command -complete=customlist,s:Complete -nargs=* ShowSlides :call s:ShowSlides(<f-args>)
+endif
+if !exists(":Odpdown")
+  command -complete=customlist,s:Complete -nargs=* Odpdown :call s:ShowSlides(<f-args>)
+endif
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set et sw=2 ts=2:

--- a/plugins/vim/odpdownhelper.py
+++ b/plugins/vim/odpdownhelper.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+from optparse import OptionParser
+import os
+import subprocess
+import sys
+import uno
+from com.sun.star.connection import NoConnectException
+
+import time
+
+port = 2002
+css = "com.sun.star"
+def trigger_open_new_file(f, present):
+    if os.fork() == 0:
+        cmdandargs = ['libreoffice', '--accept=socket,host=localhost,port=%d;urp;StarOffice.ServiceManager;tcpNoDelay=1' % port]
+        if present:
+            cmdandargs.append('--show')
+        cmdandargs.append(f)
+        subprocess.call(cmdandargs)
+        sys.exit()
+
+def trigger_close_old_file(f):
+    if os.fork() == 0:
+        time.sleep(2)
+        localContext = uno.getComponentContext()
+        servicemanager = localContext.ServiceManager
+        resolver = servicemanager.createInstanceWithContext(css+'.bridge.UnoUrlResolver', localContext)
+        context = None
+        for attempt in range(50):
+            try:
+                context = resolver.resolve('uno:socket,host=localhost,port=%d;urp;StarOffice.ComponentContext' % port)
+                break
+            except NoConnectException:
+                pass
+            time.sleep(0.1)
+        desktop = context.ServiceManager.createInstanceWithContext(css+'.frame.Desktop', context)
+        component_enumeration = desktop.Components.createEnumeration()
+        while(component_enumeration.hasMoreElements()):
+            component = component_enumeration.nextElement()
+            if component.Location == 'file://' + f and not component.isModified():
+                    component.close(True)
+                    os.unlink(f)
+                    sys.exit()
+        sys.exit()
+
+if __name__ == '__main__':
+    parser = OptionParser()
+    parser.add_option('-f', '--file', dest='filename',
+            help='open file FILE with LibreOffice', metavar='FILE')
+    parser.add_option('-o', '--oldfile', dest='oldfilename',
+            help='old file to close in LibreOffice, if opened and unmodifed', metavar='OLDFILE')
+    parser.add_option('-p', '--present', action='store_true', dest='present', default=False,
+            help='open file in presentation mode')
+    (options, args) = parser.parse_args()
+    if(options.filename):
+        trigger_open_new_file(options.filename, options.present)
+    if(options.oldfilename):
+        trigger_close_old_file(options.oldfilename)

--- a/plugins/vim/setup.py
+++ b/plugins/vim/setup.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+import os
+import os.path
+import shutil
+import subprocess
+import sys
+
+def install_vim_plugin(install_scripts):
+    src_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)),'..','..')
+    vim_plugin_dir = os.path.join(os.environ['HOME'], '.vim', 'plugin')
+    vim_plugin_data_dir = os.path.join(vim_plugin_dir,'odpdown_data')
+    vim_doc_dir = os.path.join(os.environ['HOME'], '.vim', 'doc')
+    os.makedirs(vim_plugin_data_dir, exist_ok=True)
+    os.makedirs(vim_doc_dir, exist_ok=True)
+    for demofile in ['demo-advanced.md', 'demo-basics.md', 'demo-full.md', 'discreet-dark.odp']:
+        shutil.copyfile(os.path.join(src_dir, 'demo', demofile), os.path.join(vim_plugin_data_dir, demofile))
+    with open(os.path.join(src_dir,'plugins', 'vim', 'odpdown.vim'), 'r') as script_template:
+        with open(os.path.join(vim_plugin_dir, 'odpdown.vim'), 'w') as scriptfile:
+            for line in script_template:
+                scriptfile.write(line.replace('***ODPDOWNPATH***', os.path.join(install_scripts, 'odpdown')))
+    shutil.copyfile(os.path.join(src_dir, 'plugins', 'vim', 'odpdown.txt'), os.path.join(vim_doc_dir, 'odpdown.txt'))
+    shutil.copyfile(os.path.join(src_dir, 'plugins', 'vim', 'odpdownhelper.py'), os.path.join(vim_plugin_data_dir, 'odpdownhelper.py'))
+    subprocess.call(['vim', '-s', os.path.join(src_dir, 'plugins', 'vim', 'update-help.vim')])
+    #print(src_dir, vim_plugin_dir, install_scripts)
+
+install_vim_plugin(sys.argv[1])

--- a/plugins/vim/update-help.vim
+++ b/plugins/vim/update-help.vim
@@ -1,0 +1,2 @@
+:helptags $HOME/.vim/doc
+:x


### PR DESCRIPTION
- enables showing slides from the markdown in the current vim buffer with a
  single ex command: :ShowSlides
- tested with LibreOffice 4.2 and higher and Python3 on Linux
- needs Python UNO bindings installed
- uses examples and templates from the repo as defaults
- includes custom setuptools installer option:
  python3 ./setup.py install --install-vim --user
- includes and installs vim help documenation