### PR TITLE
Workaround lpod-python missing dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ cram>=0.6
 pygments>=1.6
 pillow>=2.0
 BeautifulSoup
+lxml


### PR DESCRIPTION
It is missing lxml, until they have fixed it make odpdown working
out of the box.

Pull requested opened there:
https://github.com/lpod/lpod-python/pull/17
