### PR TITLE
demo: make odpdown binary overridable

### DIFF
--- a/demo/Makefile
+++ b/demo/Makefile
@@ -4,6 +4,8 @@ MARKDOWN=\
     demo-advanced.md \
     demo-full.md
 
+ODPDOWN?=../odpdown
+
 .PHONY: default
 default: $(patsubst %.md,%.pdf,$(MARKDOWN))
 
@@ -12,7 +14,7 @@ clean:
 	rm $(patsubst %.md,%.pdf,$(MARKDOWN)) $(patsubst %.md,%.odp,$(MARKDOWN))
 
 %.odp : %.md discreet-dark.odp Makefile
-	../odpdown -s emacs --break-master=Discreet_25_20Dark1 --content-master=Discreet_25_20Dark $< discreet-dark.odp $@
+	$(ODPDOWN) -s emacs --break-master=Discreet_25_20Dark1 --content-master=Discreet_25_20Dark $< discreet-dark.odp $@
 
 %.pdf : %.odp
 	rm -f $@


### PR DESCRIPTION
So it's easier to run when you don't have the depencies installed
system wide.