### PR TITLE
Rudimentary table support

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+v0.4.2
+ - basic support for markdown tables
+
 v0.4.1
  - Update specfile from downstream project.
  - Fix code-block ODF space misparsing bug.

--- a/demo/demo-advanced.md
+++ b/demo/demo-advanced.md
@@ -1,5 +1,12 @@
 # Advanced Markup
 
+## Basic Support for Tables
+
+| Heading 1 | Heading 2
+| --------- | ---------
+| Cell 1    | Cell 2
+| Cell 3    | Cell 4
+
 ## Embedded Image Markup
 
 ~~~

--- a/odpdown.py
+++ b/odpdown.py
@@ -51,9 +51,10 @@ from mimetypes import guess_type
 
 from lpod import ODF_MANIFEST, ODF_STYLES
 from lpod.document import odf_get_document
-from lpod.frame import odf_create_text_frame, odf_create_image_frame, odf_frame
+from lpod.frame import odf_create_text_frame, odf_create_image_frame, odf_frame, odf_create_frame
 from lpod.draw_page import odf_create_draw_page, odf_draw_page
 from lpod.list import odf_create_list_item, odf_create_list
+from lpod.table import odf_create_table, odf_create_cell, odf_create_row
 from lpod.style import odf_create_style
 from lpod.paragraph import odf_create_paragraph, odf_span
 from lpod.paragraph import odf_create_line_break, odf_create_spaces
@@ -627,13 +628,31 @@ class ODFRenderer(mistune.Renderer):
             return ODFPartialTree.from_metrics_provider([span], self)
 
     def table(self, header, body):
-        pass
+        tbl = odf_create_table(name=u'Table')
+        tbl.extend_rows(header.get())
+        tbl.extend_rows(body.get())
+
+        # TODO frame positioning, table size, style etc
+        frame = odf_create_frame(
+            style=u'md2odp-ImageStyle',
+            size=self.outline_size,
+            position=self.outline_position
+        )
+        frame.append(tbl)
+        return ODFPartialTree.from_metrics_provider([frame], self)
 
     def table_row(self, content):
-        pass
+        row = odf_create_row()
+        row.set_cells(content.get())
+        return ODFPartialTree.from_metrics_provider([row], self)
 
     def table_cell(self, content, **flags):
-        pass
+        text = content.get()[0].get_text()
+        cell = odf_create_cell(text=text, value=text)
+        # TODO header style
+        # if flags.get('header'):
+        #    cell.set_style('md2odp-TextDoubleEmphasisStyle')
+        return ODFPartialTree.from_metrics_provider([cell], self)
 
     def autolink(self, link, is_email=False):
         text = link

--- a/test.py
+++ b/test.py
@@ -274,3 +274,20 @@ next line bold**
         'text:style-name') == 'md2odp-TextDoubleEmphasisStyle')
     assert (odf.get()[0].get_elements('descendant::text:span')[3].get_text() ==
             'bold text\nnext line bold')
+
+@with_setup(setup)
+def test_basic_table():
+    markdown = '''
+|A      |B
+|-------|-------
+|Cell 1 | 2
+|[Link](http://www.odpdown.test)| Cell 4
+'''.strip()
+    odf = mkdown.render(markdown)
+    assert len(odf.get()) == 1
+    frame = odf.get()[0]
+    tbl = frame.get_table()
+    assert len(tbl.get_rows()) == 3
+    assert tbl.get_row_values(0) == ['A', 'B']
+    assert tbl.get_row_values(1) == ['Cell 1', '2']
+    assert tbl.get_row_values(2) == ['Link', 'Cell 4']


### PR DESCRIPTION
Please don't merge this patch yet since I do have a few questions:
* I couldn't figure out how to apply a certain styling for the table header. I've commented out the code and added a TODO. Any ideas?
* I've checked the mistune docs in regards to different supported layouts but haven't tested them yet. Not sure how much we'd like to support.
* Couldn't make links to appear in the table cells, since the lpod-python API seems to not support it. If there are any pointers in case you've tried it, please let me know.
At this point the implementation does all what I need. Let me know what you think.

Commit message:
Add basic support for tables. The conversion discards any styling information given by markdown. It renders the table with a fixed style.
This fix is related to #26

Ceaveats:

  * one table per slide
  * no header styling
  * no support for links in table cells