### PR TITLE
Improved unique slide and image naming

### DIFF
--- a/odpdown.py
+++ b/odpdown.py
@@ -85,9 +85,11 @@ Available master page names in template:
 
 '''.strip()
 
+
 # helper for unique hashes
 def hasher():
     return uuid4().get_hex()
+
 
 # helper for ODFFormatter and ODFRenderer
 def add_style(document, style_family, style_name,

--- a/odpdown.py
+++ b/odpdown.py
@@ -48,6 +48,7 @@ import re
 
 from urllib import urlopen
 from mimetypes import guess_type
+from uuid import uuid4
 
 from lpod import ODF_MANIFEST, ODF_STYLES
 from lpod.document import odf_get_document
@@ -63,9 +64,6 @@ from lpod.link import odf_create_link, odf_link
 
 from pygments.lexers import get_lexer_by_name
 from pygments.formatter import Formatter
-
-from uuid import uuid4
-hasher = lambda : uuid4().get_hex()
 
 __version__ = '0.4.1'
 __author__ = 'Thorsten Behrens <tbehrens@acm.org>'
@@ -87,6 +85,9 @@ Available master page names in template:
 
 '''.strip()
 
+# helper for unique hashes
+def hasher():
+    return uuid4().get_hex()
 
 # helper for ODFFormatter and ODFRenderer
 def add_style(document, style_family, style_name,
@@ -677,7 +678,7 @@ class ODFRenderer(mistune.Renderer):
         fragment_ext = urlparse.urlparse(src)[2].split('.')[-1]
         self.image_entry_id = hasher()
         fragment_name = 'Pictures/%s.%s' % (self.image_entry_id,
-                                              fragment_ext)
+                                            fragment_ext)
         imagedata = urlopen(src).read()
         try:
             if not fragment_ext.endswith('svg'):

--- a/test.py
+++ b/test.py
@@ -241,8 +241,8 @@ def test_weird_uris():
 
 '''.strip()
     mkdown.render(markdown)
-    assert u'Pictures/odpdown_image_0.svg' in testdoc.get_part(
-        ODF_MANIFEST).get_paths()
+    assert u'.svg' == testdoc.get_part(
+        ODF_MANIFEST).get_paths()[0][-4:]
 
 
 @with_setup(setup)

--- a/test.py
+++ b/test.py
@@ -241,8 +241,8 @@ def test_weird_uris():
 
 '''.strip()
     mkdown.render(markdown)
-    assert u'.svg' == testdoc.get_part(
-        ODF_MANIFEST).get_paths()[0][-4:]
+    assert u'.svg' in [x[-4:] for x in testdoc.get_part(
+        ODF_MANIFEST).get_paths()]
 
 
 @with_setup(setup)


### PR DESCRIPTION
Fixes #41 - use UUID image names for better mergeability

Added UUIDs for generating internal slide title names and stored image names. This ensures that slide names and included images will be uniquely named even across multiple generated presentations. This also seems to guarantee that multiple executions of odpdown.py can combined into a single presentation using the concatenate_presentations_cli.py scripting included in lpod-python. 

Page names in the ODP XML are given UUIDs and stored images each receive a UUID as well. Combining multiple copies of the exact same presentation will not work, but re-running odpdown.py against the source markdown will generate new unique IDs, so even that extreme use case, completely duplicating an entire presentation twice, will also work with the concatenate script. 

Previously, slide names were derived from the title of the slide, which could conflict. Images were just named sequentially which would also conflict on concatenation. This patch fixes these issues, but further room for improvement still exists.

