### PR TITLE
allow H3 headings for creating slides

### DIFF
--- a/odpdown.py
+++ b/odpdown.py
@@ -558,7 +558,7 @@ class ODFRenderer(mistune.Renderer):
                     position=(u'%s' % self.breakheader_position[0],
                               u'%s' % self.breakheader_position[1]),
                     presentation_class=u'title'))
-        elif level == 2:
+        elif (level == 2) or (level == 3):
             page = odf_create_draw_page(
                 'page1',
                 name=hasher(),


### PR DESCRIPTION
Most manuals allow for a three level heading TOC.

* H1 --> Chapter Headings
* H2 --> Section Headings
* H3 --> Subsection Headings

By allowing for slides to be created at H3, It would be easier to maintain a single source of Print, eBooks, and Slides