### PR TITLE
improve block_quotes: allow lists in them

### DIFF
--- a/odpdown.py
+++ b/odpdown.py
@@ -617,8 +617,6 @@ class ODFRenderer(mistune.Renderer):
             paras.append(para)
 
         # pylint: disable=maybe-no-member
-        # para.set_span(u'md2odp-TextQuoteStyle', regex=u'“')
-        # para.set_span(u'md2odp-TextQuoteStyle', regex=u'”')
         return ODFPartialTree.from_metrics_provider(paras, self)
 
     def list_item(self, text):


### PR DESCRIPTION
allows using lists in block_quotes.

without this change libre office does not render the lists within block quotes...
e.g.
```
> In mathematics and computer science, a higher-order function is a function that does at least one of the following:
>
> - takes one or more functions as an input
> - outputs a function
```